### PR TITLE
chore: bind <C-S-v> to <C-v>

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
 require("opts")
-require("keymaps")
+require("binds")
 require("lazy-setup")
 require("autocmds")

--- a/lua/binds.lua
+++ b/lua/binds.lua
@@ -69,6 +69,8 @@ km.set("n", "<leader>tw", "<CMD>set wrap!<CR>", { desc = "[t]oggle [w]rap" })
 km.set("v", "<leader>p", '"+p', { desc = "Paste from system clipboard" })
 km.set("n", "<leader>P", '"+P', { desc = "Paste from system clipboard" })
 
+km.set("n", "<C-S-v>", "<C-v>", { desc = "Rectangle select" })
+
 km.set("n", "<A-p>", '"_dP', { desc = "Paste without overwriting register" })
 km.set("v", "<A-p>", '"_dP', { desc = "Paste without overwriting register" })
 km.set("n", "<A-P>", '"+P', { desc = "Paste without overwriting register" })


### PR DESCRIPTION
Necessary because we're now mapping `<C-v>` to paste in the terminal.